### PR TITLE
Fix #129: rename deployments and branches

### DIFF
--- a/.env.vsp-dev-deploy
+++ b/.env.vsp-dev-deploy
@@ -1,5 +1,5 @@
-VUE_APP_AUTH_SERVER=https://viz-auth.vsp.tu-berlin.de
-VUE_APP_FILE_SERVER=https://viz-files.vsp.tu-berlin.de
-VUE_APP_FRAME_ANIMATION_SERVER=https://viz-frani.vsp.tu-berlin.de
+VUE_APP_AUTH_SERVER=https://viz-auth-play.vsp.tu-berlin.de
+VUE_APP_FILE_SERVER=https://viz-files-play.vsp.tu-berlin.de
+VUE_APP_FRAME_ANIMATION_SERVER=https://viz-frani-play.vsp.tu-berlin.de
 VUE_APP_ID=viz-client-dev
 VUE_APP_AUTH_CALLBACK=https://viz-dev.vsp.tu-berlin.de/authentication

--- a/.env.vsp-play-deploy
+++ b/.env.vsp-play-deploy
@@ -1,5 +1,0 @@
-VUE_APP_AUTH_SERVER=https://viz-auth-play.vsp.tu-berlin.de
-VUE_APP_FILE_SERVER=https://viz-files-play.vsp.tu-berlin.de
-VUE_APP_FRAME_ANIMATION_SERVER=https://viz-frani-play.vsp.tu-berlin.de
-VUE_APP_ID=viz-client-play
-VUE_APP_AUTH_CALLBACK=https://viz-play.vsp.tu-berlin.de/authentication

--- a/.env.vsp-staging-deploy
+++ b/.env.vsp-staging-deploy
@@ -1,0 +1,5 @@
+VUE_APP_AUTH_SERVER=https://viz-auth.vsp.tu-berlin.de
+VUE_APP_FILE_SERVER=https://viz-files.vsp.tu-berlin.de
+VUE_APP_FRAME_ANIMATION_SERVER=https://viz-frani.vsp.tu-berlin.de
+VUE_APP_ID=viz-client-staging
+VUE_APP_AUTH_CALLBACK=https://viz-staging.vsp.tu-berlin.de/authentication

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ addons:
 
 branches:
   only:
-    - stable
     - master
+    - staging
     - dev
 
 # build the webapp into ./dist
 # travis doesn't have the option to run different builds for different branches, so we have to
 # it with ugly bash if statements
 script:
-  - if [ "$TRAVIS_BRANCH" == "stable"]; then npm run build && npm run unit; fi
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then npm run build-dev && npm run unit; fi
-  - if [ "$TRAVIS_BRANCH" == "dev" ]; then npm run build-play && npm run unit; fi
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then npm run build && npm run unit; fi
+  - if [ "$TRAVIS_BRANCH" == "staging"]; then npm run build-staging && npm run unit; fi
+  - if [ "$TRAVIS_BRANCH" == "dev" ]; then npm run build-dev && npm run unit; fi
 
 # the script statement for each deploy refer to the deploy.sh script because the script tag in the deploy section
 # only supports one command...
@@ -27,15 +27,15 @@ deploy:
   - on:
       branch: master
     provider: script
-    script: bash deploy.sh viz-dev
+    script: bash deploy.sh viz
     skip_cleanup: true
   - on:
-      branch: stable
+      branch: staging
     provider: script
-    script: bash deploy.sh viz
+    script: bash deploy.sh viz-staging
     skip_cleanup: true
   - on:
       branch: dev
     provider: script
-    script: bash deploy.sh viz-play
+    script: bash deploy.sh viz-dev
     skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint",
     "build": "vue-cli-service build --mode vsp-production-deploy",
     "build-dev": "vue-cli-service build --mode vsp-dev-deploy",
-    "build-play": "vue-cli-service build --mode vsp-play-deploy",
+    "build-staging": "vue-cli-service build --mode vsp-staging-deploy",
     "test:unit": "vue-cli-service test:unit",
     "unit": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
master -> is now our production build
staging -> is now the UI staging area, points to prod backend
dev -> is our playground, with a separate backend

VORSICHT! This will require renaming branches.